### PR TITLE
fix varchar to datetime error #1075 (SQLServer)

### DIFF
--- a/src/Phinx/Db/Adapter/SqlServerAdapter.php
+++ b/src/Phinx/Db/Adapter/SqlServerAdapter.php
@@ -1177,4 +1177,14 @@ SQL;
     {
         return array_merge(parent::getColumnTypes(), array('filestream'));
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function migrated(MigrationInterface $migration, $direction, $startTime, $endTime)
+    {
+        $startTime = str_replace(' ', 'T', $startTime);
+        $endTime = str_replace(' ', 'T', $endTime);
+        return parent::migrated($migration, $direction, $startTime, $endTime);
+    }
 }


### PR DESCRIPTION
fixes #1075
Replace space between date and time with a T according to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)